### PR TITLE
docs: explain that channelId must be specified as a string for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ const WebhookRouter = require('amio-sdk-js').WebhookRouter
 const amioWebhookRouter = new WebhookRouter({
     secrets: {
       // CHANNEL_ID: SECRET
+      // !!! CHANNEL_ID must be a string. The numbers can be converted to a different value
       // get CHANNEL_ID at https://app.amio.io/administration/channels/
       // get SECRET at https://app.amio.io/administration/channels/{{CHANNEL_ID}}/webhook
       '15160185464897428':'thzWPzSPhNjfdKdfsLBEHFeLWW',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amio-sdk-js",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Multi-messenger javascript library for Amio.io API. https://amio.io",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
check issue for explanation